### PR TITLE
fix - in PROJECT_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VENV := $(PWD)/.venv
 DEPS := $(VENV)/.deps
 PYTHON := $(VENV)/bin/python
 PYTHON_CMD := PYTHONPATH=$(CURDIR) $(PYTHON)
-PROJECT_NAME=$(shell basename $(CURDIR))
+PROJECT_NAME=$(shell basename $(CURDIR) | tr - _)
 PYLINT_CMD := $(PYTHON_CMD) -m pylint $(PROJECT_NAME) test
 
 ifndef VERBOSE


### PR DESCRIPTION
* supports github project naming convention e.g. `foo-bar`